### PR TITLE
Exporter 3.0 should respect sharing scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.22.24</version>
+            <version>0.22.28</version>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/BRIDGE-3092

See also https://github.com/Sage-Bionetworks/BridgeServer2/pull/438

Also, clean up Synapse resources so we don't end up flooding Synapse with test objects.