### PR TITLE
DHP-875 Fix "Expected application/json but received text/html"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.sagebionetworks</groupId>
             <artifactId>bridge-base</artifactId>
-            <version>2.7.32</version>
+            <version>2.8.7</version>
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks</groupId>


### PR DESCRIPTION
Fix for https://sagebionetworks.jira.com/browse/DHP-875

Example stack trace

```
java.util.concurrent.ExecutionException: org.sagebionetworks.client.exceptions.SynapseClientException: Expected application/json but received text/html
	at java.util.concurrent.FutureTask.report(FutureTask.java:122)
	at java.util.concurrent.FutureTask.get(FutureTask.java:192)
	at org.sagebionetworks.bridge.exporter.integration.Exporter3Test.verifyDemographicsViewRowsForVersion(Exporter3Test.java:918)
	at org.sagebionetworks.bridge.exporter.integration.Exporter3Test.demographics(Exporter3Test.java:832)
Caused by: org.sagebionetworks.client.exceptions.SynapseClientException: Expected application/json but received text/html
	at org.sagebionetworks.client.BaseClientImpl.validateContentType(BaseClientImpl.java:498)
	at org.sagebionetworks.client.BaseClientImpl.getJson(BaseClientImpl.java:510)
	at org.sagebionetworks.client.SynapseClientImpl.getAsynchJobResponse(SynapseClientImpl.java:2557)
	at org.sagebionetworks.client.SynapseClientImpl.getAsyncResult(SynapseClientImpl.java:2540)
	at org.sagebionetworks.client.SynapseClientImpl.queryTableEntityBundleAsyncGet(SynapseClientImpl.java:3906)
	at org.sagebionetworks.bridge.exporter.integration.Exporter3Test.lambda$querySynapseTable$0(Exporter3Test.java:1212)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

The failures always seem to be related to queryTableEntityBundle. This is an async call in a loop without any retries, so if one of the calls fail, the whole test fails. This change adds retries to querySynapseTable (via bridge-base) so that the test is more robust.

Requires https://github.com/Sage-Bionetworks/bridge-base/pull/103