### PR TITLE
add sessionName to export metadata

### DIFF
--- a/src/test/java/org/sagebionetworks/bridge/exporter/integration/Exporter3Test.java
+++ b/src/test/java/org/sagebionetworks/bridge/exporter/integration/Exporter3Test.java
@@ -627,7 +627,10 @@ public class Exporter3Test {
         expectedMetadata.put("assessmentInstanceGuid", 
                 timeline.getSchedule().get(0).getAssessments().get(0).getInstanceGuid());
         expectedMetadata.put("sessionInstanceGuid", timeline.getSchedule().get(0).getInstanceGuid());
+        String sessionRefId = timeline.getSchedule().get(0).getRefGuid();
+        String sessionName = timeline.getSessions().stream().filter(s -> s.getGuid().equals(sessionRefId)).findFirst().get().getLabel();
         expectedMetadata.put("sessionGuid", timeline.getSchedule().get(0).getRefGuid());
+        expectedMetadata.put("sessionName", sessionName);
         expectedMetadata.put("sessionInstanceStartDay", timeline.getSchedule().get(0).getStartDay().toString());
         expectedMetadata.put("sessionInstanceEndDay", timeline.getSchedule().get(0).getEndDay().toString());
         expectedMetadata.put("sessionStartEventId", "enrollment");


### PR DESCRIPTION
We added sessionName to TimelineMetadata in https://github.com/Sage-Bionetworks/BridgeServer2/pull/677 However, there were required Integ Test changes that were rolled into https://github.com/Sage-Bionetworks/BridgeWorkerIntegrationTests/pull/63 that haven't been merged yet. This broke integ tests in Dev.

This pull request adds those changes to integ tests to unblock integ tests.